### PR TITLE
Fix sending emails using the 'name <email>' format

### DIFF
--- a/Mail/Helper.php
+++ b/Mail/Helper.php
@@ -101,7 +101,7 @@ class Helper implements HelperInterface
 
         $this->logger->info(sprintf(
             'Try register mail from L91 FormBundle: ' . PHP_EOL .
-            '   From: ' . $fromMail . PHP_EOL .
+            '   From: ' . serialize($fromMail) . PHP_EOL .
             '   To: ' . $toMail . PHP_EOL .
             ($replayTo != null) ? 'Reply to: ' . $replayTo . PHP_EOL : '' .
             '   Subject: ' . $subject


### PR DESCRIPTION
Trying to set the 'From' address as 'name <email>' currently
fails because the logging can't handle array-variables. This
patch serializes the $fromMail variable for the logger which
fixes the issue.

Fixes #23
